### PR TITLE
Change Package.json Main Value

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-mouse-aware",
   "version": "0.1.0",
   "description": "A tiny higher order component to track mouse state.",
-  "main": "index.js",
+  "main": "./lib",
   "scripts": {
     "test": "./scripts/test.sh"
   },


### PR DESCRIPTION
- Change `main` config variable from `index.js` to `./lib`. When build is ran, it builds with babel into the `lib` directory, and also places `index.js` in the lib directory as well. When importing, it was looking for `react-mouse-aware/index.js` instead of `react-mouse-aware/lib/index.js`
